### PR TITLE
Fix on predictions

### DIFF
--- a/classification_identification/launch-predictions-task2.sh
+++ b/classification_identification/launch-predictions-task2.sh
@@ -45,7 +45,6 @@ python build_input_data_model.py \
     ${DICT_PRODUCTS_PATH_FILE} \
     ${DICT_QUERIES_PATH_FILE} \
     ${TEST_PUBLIC_PATH_FILE} \
-    ${TRAIN_PATH_FILE} \
     ${ARRAY_QUERIES_PATH_FILE} \
     ${ARRAY_PRODUCTS_PATH_FILE} \
     --bert_size ${BERT_SIZE}


### PR DESCRIPTION
In the part of # 2. Build inputs datasets from BERT representations, there's a Redundant param {TRAIN_PATH_FILE}, preventing the prediction from starting properly(throwing an error"error: unrecognized arguments: ./text_representations/task2/array_product_test_public-v0.2.npy").

*Description of changes:* remove {TRAIN_PATH_FILE}


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
